### PR TITLE
Fixed error suppression on MacOS/ARM

### DIFF
--- a/tests/test_h.py
+++ b/tests/test_h.py
@@ -52,8 +52,8 @@ with contextlib.suppress(ImportError):
     import numpy as np
 
     _OUTCOME_TYPES += (
-        np.int64,
-        np.float128,
+        np.longlong,
+        np.longdouble,
     )
 
 with contextlib.suppress(ImportError):


### PR DESCRIPTION
The tests couldn't run on macOS/ARM:

`
========================================= ERRORS ==========================================
____________________________ ERROR collecting tests/test_h.py _____________________________
tests/test_h.py:56: in <module>
    np.float128,
    ^^^^^^^^^^^
.venv/lib/python3.11/site-packages/numpy/__init__.py:792: in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")
E   AttributeError: module 'numpy' has no attribute 'float128'
`

It works fine from a Docker (Ubuntu latest on ARM), but Numpy seems to have a slightly different interface on macOS.

This little fix allows running the unit tests on a macOS host.






