### PR TITLE
Adds experimental H.quantile method

### DIFF
--- a/docs/notes.md
+++ b/docs/notes.md
@@ -34,7 +34,8 @@
 - Removes `P.map`, `P.rmap`, and `P.umap` in favor of [`P.apply_to_each_h`][dyce.P.apply_to_each_h].
 - Removes `P.is_homogeneous`.
 - Adds optional `preserve_zero_counts` parameter to [`H.lowest_terms`][dyce.H.lowest_terms].
-- Adds experimental [`H.quantize`][dyce.H.quantize] method.
+- Adds experimental [`H.quantile`][dyce.H.quantile] method.
+- Adds experimental [`H.quantize` method][dyce.H.quantize] and [`quantize_hs` context manager][dyce.quantize_hs].
 - Adds experimental (and somewhat inefficient) [`H.replace`][dyce.H.replace] method.
 - Adds experimental [`P.apply_to_each_roll`][dyce.P.apply_to_each_roll] method.
 - Simplifies and consolidates `dyce.evaluation.expandable` and `dyce.evaluation.foreach` into [`expand`][dyce.expand] (still experimental).

--- a/dyce/h.py
+++ b/dyce/h.py
@@ -1660,6 +1660,45 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
         for outcome, count in self._h.items():
             yield outcome, rational_t(count, t)
 
+    @experimental
+    def quantile(self: "H[_T]", numerator: SupportsInt, denominator: SupportsInt) -> _T:
+        r"""
+        Returns the smallest outcome whose cumulative probability (i.e., including all smaller weighted outcomes) is at least *numerator* / *denominator*.
+        It matches NumPy's `numpy.quantile(outcomes, numerator / denominator, weights=counts, method="inverted_cdf")` (the step-function quantile appropriate to a discrete distribution), but stays integer-exact rather than rounding through `float`.
+        Raises `ValueError` if the histogram is empty, if *denominator* is not positive, or if *numerator* / *denominator* lies outside the closed interval `#!math \left[ 0, 1 \right]`.
+
+            >>> (2 @ H(10)).quantile(1, 3)
+            9
+            >>> H(6).quantile(0, 1)
+            1
+            >>> H(6).quantile(1, 2)
+            3
+            >>> H(6).quantile(1, 1)
+            6
+        """
+        if not self._h:
+            raise ValueError("quantile of empty histogram is undefined")
+        numerator = lossless_int(numerator)
+        denominator = lossless_int(denominator)
+        if denominator <= 0:
+            raise ValueError(f"denominator ({denominator!r}) must be positive")
+        if not 0 <= numerator <= denominator:
+            raise ValueError(
+                f"numerator / denominator ({numerator}/{denominator}) must be in the interval [0, 1]"
+            )
+        # `cumulative / total >= numerator / denominator` cross-multiplies to
+        # `cumulative * denominator >= numerator * total` for `denominator > 0 and total
+        # > 0` (i.e., no sign flip)
+        scaled_target = numerator * self.total
+        cumulative = 0
+        for outcome, count in self.items():
+            cumulative += count
+            if cumulative * denominator >= scaled_target:
+                return outcome
+        raise AssertionError(
+            "unreachable: cumulative reaches total"
+        )  # pragma: no cover
+
     @overload
     def quantize(
         self: "H[Never]",

--- a/tests/test_h.py
+++ b/tests/test_h.py
@@ -840,6 +840,88 @@ class TestHProbabilityItems:
         assert total == Fraction(1)
 
 
+class TestHQuantile:
+    _SAMPLE_HS = (
+        H(4),
+        2 @ H(10),
+        H(8) + H(12),
+        3 @ H(6),
+        H({1: 5, 6: 1}),  # heavily skewed
+        H({-3: 5, 2: 1, 7: 100}),  # negative + uneven weights
+        H(20),
+        H(100),
+        H(1_000_000),
+    )
+
+    def test_matches_issue_reference(self) -> None:
+        assert (2 @ H(10)).quantile(1, 3) == 9
+
+    def test_endpoints_are_min_and_max(self) -> None:
+        for h in (
+            *self._SAMPLE_HS,
+            20 @ H(20),
+        ):
+            assert h.quantile(0, 1) == min(h.outcomes())
+            assert h.quantile(1, 1) == max(h.outcomes())
+
+    def test_returns_an_outcome_not_a_derived_value(self) -> None:
+        for h in (
+            *self._SAMPLE_HS,
+            20 @ H(20),
+        ):
+            assert h.quantile(1, 2) in h.outcomes()
+
+    def test_exact_boundary_includes_the_outcome(self) -> None:
+        # 1/10 is exactly the cumulative probability at outcome 2 (2/20), where a float
+        # value of 0.1 (i.e., 0.1000000000000000055511151231257827021181583404541015625)
+        # may be over-inclusive
+        assert H(20).quantile(1, 10) == 2
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"\bempty histogram\b"):
+            H({}).quantile(1, 2)
+
+    def test_nonpositive_denominator_raises(self) -> None:
+        for denominator in (0, -2):
+            with pytest.raises(ValueError, match=r"\bdenominator\b.*\bpositive\b"):
+                H(6).quantile(1, denominator)
+
+    def test_out_of_range_raises(self) -> None:
+        for numerator, denominator in ((-1, 2), (3, 2), (5, 4)):
+            with pytest.raises(ValueError, match=r"\binterval \[0, 1\]"):
+                H(6).quantile(numerator, denominator)
+
+    @pytest.mark.skipif(find_spec("numpy") is None, reason="requires numpy")
+    def test_matches_numpy_inverted_cdf(self) -> None:
+        import numpy as np
+
+        for h in self._SAMPLE_HS:
+            assert h.total <= 2**53, (
+                f"{h.total} is too big for numpy to represent weights internally ({h.total} > 2**53)"
+            )
+            outcomes = np.array(list(h.outcomes()), dtype=float)
+            counts = np.array(list(h.counts()), dtype=float)
+            for numerator, denominator in (
+                (0, 1),
+                (1, 10),
+                (1, 3),
+                (1, 2),
+                (3, 4),
+                (9, 10),
+                (99, 100),
+                (1, 1),
+            ):
+                want = np.quantile(
+                    outcomes,
+                    numerator / denominator,
+                    weights=counts,
+                    method="inverted_cdf",
+                )
+                assert h.quantile(numerator, denominator) == want, (
+                    f"h={dict(h)} q={numerator}/{denominator}"
+                )
+
+
 class TestHQuantize:
     def test_quantize_empty(self) -> None:
         h = H({})


### PR DESCRIPTION
Includes tests and mention in docs/notes.md. Also corrects for missing note about previously-committed `quantize_hs` context manager.

Fixes #32.