### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/dyce/__init__.py
+++ b/dyce/__init__.py
@@ -22,6 +22,11 @@ Additionally, `dyce` provides [`expand`][dyce.expand], which is useful for subst
 It also provides [`explode_n`][dyce.explode_n] as a convenient shorthand.
 """
 
+if True:  # so ruff won't complain imports are out-of-order, but still sort the others
+    from .types import beartype_this_package
+
+    beartype_this_package()
+
 from importlib.metadata import PackageNotFoundError, version
 
 from .evaluation import HResult, PResult, TruncationWarning, expand, explode_n

--- a/dyce/h.py
+++ b/dyce/h.py
@@ -386,7 +386,7 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
 
         if isinstance(init_val, Iterable):
             if isinstance(init_val, Mapping):
-                self._h = dict(_sorted_items_iter(list(init_val.items())))  # ty: ignore[invalid-argument-type]
+                self._h = dict(_sorted_items_iter(list(init_val.items())))
             else:
                 c: Counter[_T_co] = Counter(init_val)
                 self._h = dict(_sorted_items_iter(list(c.items())))
@@ -1121,7 +1121,7 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
             >>> H(6).eq(H(10)).lowest_terms()
             H({False: 9, True: 1})
         """
-        return self.apply(ot.do_eq, rhs)  # ty: ignore[no-matching-overload]
+        return self.apply(ot.do_eq, rhs)
 
     @overload
     def ne(self: "H[ot.CanNe[_OtherT, bool]]", rhs: "H[_OtherT]") -> "H[bool]": ...
@@ -1136,7 +1136,7 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
             >>> H(6).ne(H(10)).lowest_terms()
             H({False: 1, True: 9})
         """
-        return self.apply(ot.do_ne, rhs)  # ty: ignore[no-matching-overload]
+        return self.apply(ot.do_ne, rhs)
 
     @overload
     def ge(self: "H[ot.CanGe[_OtherT, bool]]", rhs: "H[_OtherT]") -> "H[bool]": ...
@@ -1233,7 +1233,7 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
         result: dict[_T, int] = dict(self)
         other_h = other if isinstance(other, H) else H(other)
         for outcome, count in other_h.items():
-            result[outcome] = result.get(outcome, 0) + count  # ty: ignore[invalid-assignment]
+            result[outcome] = result.get(outcome, 0) + count
         return H(result)
 
     @overload
@@ -1794,7 +1794,7 @@ class H(Mapping[_T_co, int], Iterable[_T_co]):  # type: ignore[type-var] # ty: i
                 if outcome != existing_outcome
             }
             for repl_outcome, repl_count in repl.items():
-                d[repl_outcome] = (  # ty: ignore[invalid-assignment]
+                d[repl_outcome] = (
                     d.get(repl_outcome, 0) + repl_count * existing_outcome_count
                 )
         else:

--- a/dyce/types.py
+++ b/dyce/types.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from types import (
     NotImplementedType,  # ruff: ignore[typing-only-standard-library-import]
 )
-from typing import Any, SupportsIndex, SupportsInt, TypeVar
+from typing import TYPE_CHECKING, Any, SupportsIndex, SupportsInt, TypeVar
 
 __all__ = (
     "GetItemT",
@@ -28,42 +28,52 @@ __all__ = (
     "natural_key",
 )
 
-try:
-    from beartype.roar import (
-        BeartypeCallHintViolation,  # pyright: ignore[reportAssignmentType]
-    )
-except ImportError:  # pragma: no cover
-
-    class BeartypeCallHintViolation(Exception):  # type: ignore[no-redef] # ruff: ignore[error-suffix-on-exception-name]
-        pass
-
 
 _T = TypeVar("_T")
 
-try:
-    from beartype import BeartypeConf, BeartypeStrategy, beartype
 
-    nobeartype = beartype(
-        conf=BeartypeConf(
-            strategy=BeartypeStrategy.O0,
+DYCE_IS_BEARIFIED = False
+
+
+class BeartypeCallHintViolation(Exception):  # ruff: ignore[error-suffix-on-exception-name]
+    pass
+
+
+class BeartypeConf:
+    pass
+
+
+_DUMMY_BEARTYPE_CONF = BeartypeConf()
+
+
+def beartype_this_package(*, conf: BeartypeConf = _DUMMY_BEARTYPE_CONF) -> None:
+    pass
+
+
+def nobeartype(arg: _T) -> _T:
+    return arg
+
+
+if not TYPE_CHECKING:  # pragma: no cover
+    try:
+        from beartype import (  # type: ignore[import-not-found] # ty: ignore[unresolved-import]
+            BeartypeConf,
+            BeartypeStrategy,
+            beartype,
         )
-    )  # pyright: ignore[reportAssignmentType]
-except ImportError:  # pragma: no cover
+        from beartype.claw import beartype_this_package  # ruff: ignore[unused-import]
+        from beartype.roar import (  # type: ignore[import-not-found] # ty: ignore[unresolved-import]
+            BeartypeCallHintViolation,  # pyright: ignore[reportAssignmentType] # ruff: ignore[unused-import]
+        )
 
-    def nobeartype(arg: _T) -> _T:
-        return arg
-
-
-def _bearified_canary() -> None:
-    return False  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-
-
-try:
-    _bearified_canary()
-except BeartypeCallHintViolation:  # pragma: no cover
-    DYCE_IS_BEARIFIED = True
-else:  # pragma: no cover
-    DYCE_IS_BEARIFIED = False
+        nobeartype = beartype(
+            conf=BeartypeConf(
+                strategy=BeartypeStrategy.O0,
+            )
+        )  # pyright: ignore[reportAssignmentType]
+        DYCE_IS_BEARIFIED = True
+    except ImportError:  # pragma: no cover
+        pass
 
 
 class SentinelT:

--- a/helpers/check-doctests.py
+++ b/helpers/check-doctests.py
@@ -409,12 +409,12 @@ def _load_toml_config(  # ruff: ignore[complex-structure]
                 continue  # sub-table; handled below
             elif key in _TOML_SHARED_STR_KEYS:
                 if isinstance(val, str):
-                    shared[key] = val  # ty: ignore[invalid-assignment]
+                    shared[key] = val
                 else:
                     _LOGGER.warning("%s: %s must be a string; ignoring", candidate, key)
             elif key in _TOML_SHARED_STR_LIST_KEYS:
                 if isinstance(val, list) and all(isinstance(s, str) for s in val):
-                    shared[key] = val  # ty: ignore[invalid-assignment]
+                    shared[key] = val
                 else:
                     _LOGGER.warning(
                         "%s: %s must be a list of strings; ignoring", candidate, key
@@ -441,7 +441,7 @@ def _load_toml_config(  # ruff: ignore[complex-structure]
                                 and all(isinstance(t, str) for t in cmd)
                                 for cmd in val
                             ):
-                                sub[key] = val  # ty: ignore[invalid-assignment]
+                                sub[key] = val
                             else:
                                 _LOGGER.warning(
                                     "%s: checkers must be a list of string lists; ignoring",
@@ -449,7 +449,7 @@ def _load_toml_config(  # ruff: ignore[complex-structure]
                                 )
                         elif key in _TOML_CHECK_BOOL_KEYS:
                             if isinstance(val, bool):
-                                sub[key] = val  # ty: ignore[invalid-assignment]
+                                sub[key] = val
                             else:
                                 _LOGGER.warning(
                                     "%s: %s must be a boolean; ignoring",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ docs = [
 ]
 # Only what's needed for uv run pre-commit run --all-files --hook-stage pre-push
 lint = [
-    "beartype",
     "matplotlib_inline",
     "mypy",
     "pre-commit",
@@ -96,20 +95,22 @@ lint = [
     "pyright",
     "pytest",
     "ruff",
-    "ty",
+    "ty>=0.0.70",  # TODO(posita): https://github.com/astral-sh/ty/issues/4222
     {include-group = "docs"},
 ]
 # Only what's needed for uv run pytest --cov
 test = [
-    "beartype",
     "coverage[toml]",
     "numpy",
     "pandas",
-    "pytest-beartype",
     "pytest-benchmark",
     "pytest-cov",
     {include-group = "test-pypy"},
     {include-group = "viz"},
+]
+test-beartype = [
+    "beartype>=0.23.0rc0",
+    {include-group = "test"},
 ]
 # Only what's needed for uv run pytest specifically with PyPy (via Tox)
 test-pypy = [
@@ -186,31 +187,32 @@ docstring-code-line-length = "dynamic"
 
 [tool.ruff.lint.per-file-ignores]
 "docs/assets/nb_*.py" = [
-  # Allow co-mingled imports for snippets
-  "E402",  # Module level import not at top of file
-  # ruff is confused by jupytext comments
-  "ERA001",  # Found commented-out code
   # Cells support `await` statements
-  "F704",  # `await` statement outside of a function
-  "PLE1142",  # `await` should be used within an async function
+  "await-outside-async",
+  "yield-outside-function",
+  # ruff is confused by jupytext comments
+  "commented-out-code",
+  # Allow co-mingled imports for snippets
+  "module-import-not-at-top-of-file",
   # Useful for cell display
-  "B018",   # Found useless expression
-  "T201",  # `print` found (eglot-check)
+  "print",
+  "useless-expression",
   # Catch-all for things that are only ignored in these files
-  "RUF100",  # Unused `noqa` directive ...
+  "unused-noqa",
 ]
 "docs/assets/plot_*.py" = [
   # Allow co-mingled imports for snippets
-  "E402",  # Module level import not at top of file
+  "module-import-not-at-top-of-file",
   # Useful for cell display
-  "B018",   # Found useless expression
-  "T201",  # `print` found (eglot-check)
+  "print",
+  "useless-expression",
 ]
 "docs/notebooks/*.ipynb" = [
-  "E402",  # Module level import not at top of file
+  # Allow co-mingled imports for snippets
+  "module-import-not-at-top-of-file",
   # Useful for cell display
-  "B018",   # Found useless expression
-  "T201",  # `print` found (eglot-check)
+  "print",
+  "useless-expression",
 ]
 
 [tool.ruff.lint]
@@ -223,18 +225,18 @@ ignore = [
   "FIX",  # TODO(posita): run occasionally, or figure out how to make these warnings
   "PLC",
   "PLR",
-  "COM812",  # Trailing comma missing
-  "E501",  # Line too long (... > ...)
-  "INP001",  # File ... is part of an implicit namespace package. Add an `__init__.py`.
-  "N806",  # Variable ... in function should be lowercase
-  "RET505",  # Unnecessary `else` after `return` statement
-  "RET506",  # Unnecessary `else` after `raise` statement
-  "RET507",  # Unnecessary `else` after `continue` statement
-  "RUF002",  # Docstring contains ambiguous ...
-  "RUF067",  # `__init__` module should only contain docstrings and re-exports
-  "S101",  # Use of `assert` detected
-  "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes
-  "TRY003",  # Avoid specifying long messages outside the exception class
+  "ambiguous-unicode-character-docstring",
+  "assert",
+  "implicit-namespace-package",
+  "line-too-long",
+  "missing-trailing-comma",
+  "non-empty-init-module",
+  "non-lowercase-variable-in-function",
+  "raise-vanilla-args",
+  "superfluous-else-continue",
+  "superfluous-else-raise",
+  "superfluous-else-return",
+  "suspicious-non-cryptographic-random-usage",
 ]
 select = [
   "ALL",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -19,7 +19,7 @@ from collections.abc import Callable
 from enum import IntEnum, auto
 from fractions import Fraction
 from importlib.util import find_spec
-from typing import Any, Never, cast
+from typing import Any, Never
 
 import pytest
 
@@ -152,7 +152,7 @@ class TestExpandTruncation:
         # is dropped, leaving an empty histogram. A TruncationWarning is emitted
         # by the innermost expand that catches the RecursionError.
         def _always_recurses(result: HResult[int]) -> H[int] | int:
-            return expand(_always_recurses, result.h) + 1  # ty: ignore[unsupported-operator]
+            return expand(_always_recurses, result.h) + 1
 
         with pytest.warns(TruncationWarning, match=r"\brecursion\b"):
             result = expand(_always_recurses, d1)
@@ -219,14 +219,11 @@ def _explode_with_truncation(
         return result.outcome
     else:
         return (
-            cast(
-                "H[int]",
-                expand(
-                    _explode_with_truncation,
-                    result.h,
-                    rcrs_err_countdown=rcrs_err_countdown - 1,
-                    truncate_countdown=truncate_countdown - 1,
-                ),
+            expand(
+                _explode_with_truncation,
+                result.h,
+                rcrs_err_countdown=rcrs_err_countdown - 1,
+                truncate_countdown=truncate_countdown - 1,
             )
             + result.outcome
         )

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ isolated_build = true
 [testenv]
 runner = uv-venv-lock-runner
 commands =
-    beartype-!pypy{311}: pytest -m 'not benchmark' --beartype-packages dyce {posargs}
-    !beartype: pytest -m 'not benchmark' {posargs}
+    pytest -m 'not benchmark' {posargs}
 dependency_groups =
-    !pypy311: test
+    !beartype-!pypy311: test
+    beartype-!pypy311: test-beartype
     pypy311: test-pypy
 package = editable

--- a/uv.lock
+++ b/uv.lock
@@ -168,11 +168,11 @@ wheels = [
 
 [[package]]
 name = "beartype"
-version = "0.22.9"
+version = "0.23.0rc0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/6d/158a00013b4b7726d69aa273eab7a5f329ea973edc0c626c4394c50231e5/beartype-0.23.0rc0.tar.gz", hash = "sha256:3cc8fd69a9a1f4a9ee5bdc20cd9c26962e2db3ef4c388e3181dd7f226c5c5d6f", size = 1928474, upload-time = "2026-08-08T07:26:47.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a3/ba8699a1361099ff9162c9b5de6e024f75c2dff1f753c2b58beb719d9519/beartype-0.23.0rc0-py3-none-any.whl", hash = "sha256:5a6647bc6a777ead26fb1a781831aea95e29975cae8db26d5882f6147a45fae3", size = 1530796, upload-time = "2026-08-08T07:26:45.829Z" },
 ]
 
 [[package]]
@@ -658,7 +658,6 @@ viz = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "beartype" },
     { name = "click" },
     { name = "coverage", extra = ["toml"] },
     { name = "griffe-warnings-deprecated" },
@@ -688,7 +687,6 @@ dev = [
     { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-beartype" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -720,7 +718,6 @@ docs = [
     { name = "sympy" },
 ]
 lint = [
-    { name = "beartype" },
     { name = "click" },
     { name = "griffe-warnings-deprecated" },
     { name = "jupyter-server" },
@@ -752,6 +749,19 @@ lint = [
     { name = "ty" },
 ]
 test = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "griffe-warnings-deprecated" },
+    { name = "ipdb" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pandas" },
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-cov" },
+    { name = "sympy" },
+]
+test-beartype = [
     { name = "beartype" },
     { name = "coverage", extra = ["toml"] },
     { name = "griffe-warnings-deprecated" },
@@ -761,7 +771,6 @@ test = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pandas" },
     { name = "pytest" },
-    { name = "pytest-beartype" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "sympy" },
@@ -790,7 +799,6 @@ provides-extras = ["viz"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "beartype" },
     { name = "click", specifier = ">=8.3.2" },
     { name = "coverage", extras = ["toml"] },
     { name = "griffe-warnings-deprecated" },
@@ -819,14 +827,13 @@ dev = [
     { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-beartype" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sympy" },
     { name = "tox" },
     { name = "tox-uv" },
-    { name = "ty" },
+    { name = "ty", specifier = ">=0.0.70" },
 ]
 docs = [
     { name = "click", specifier = ">=8.3.2" },
@@ -850,7 +857,6 @@ docs = [
     { name = "sympy" },
 ]
 lint = [
-    { name = "beartype" },
     { name = "click", specifier = ">=8.3.2" },
     { name = "griffe-warnings-deprecated" },
     { name = "jupyter-server" },
@@ -878,10 +884,9 @@ lint = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "sympy" },
-    { name = "ty" },
+    { name = "ty", specifier = ">=0.0.70" },
 ]
 test = [
-    { name = "beartype" },
     { name = "coverage", extras = ["toml"] },
     { name = "griffe-warnings-deprecated" },
     { name = "ipdb" },
@@ -889,7 +894,19 @@ test = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pytest" },
-    { name = "pytest-beartype" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-cov" },
+    { name = "sympy" },
+]
+test-beartype = [
+    { name = "beartype", specifier = ">=0.23.0rc0" },
+    { name = "coverage", extras = ["toml"] },
+    { name = "griffe-warnings-deprecated" },
+    { name = "ipdb" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "sympy" },
@@ -2212,7 +2229,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/86/e6f1f6f3487492dfcf3b7a2d4e2534d27af6ac05b364b276706906c34865/optype-0.17.1.tar.gz", hash = "sha256:07bfa32b795dea28fba8605a6288d36370d072f25183fb9c29b5a90f4b6f5638", size = 53572, upload-time = "2026-05-17T22:13:28.725Z" }
 wheels = [
@@ -2235,7 +2252,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/51/51dc9b1009e020f44703933d4d1ee3429c647c026ce7806b37ee2b257998/optype-0.18.0.tar.gz", hash = "sha256:ea10dee61b15ca299ed0d97025d362585c4dfc5481159bb999a1d0d414bbcb04", size = 59967, upload-time = "2026-06-07T22:13:17.534Z" }
 wheels = [
@@ -2691,19 +2708,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
-]
-
-[[package]]
-name = "pytest-beartype"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/63/69/954ee438f1c72f4247b09381cd07a7d776ebdb4f6c0359b3b971676a2eef/pytest_beartype-0.2.0.tar.gz", hash = "sha256:9eeec379f812e0e5c9c1bb7e95d90a33a79c387034f2d735e03bc9aa0fd7cf3f", size = 5871, upload-time = "2024-10-31T17:52:35.974Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/69/87efc2482aab172a32e4147eb5666ebc2e4c875e17d3104878553720a83a/pytest_beartype-0.2.0-py3-none-any.whl", hash = "sha256:be6be04be4a143f965f21140d6661bab43dcd7c761d50cf6daa1b16848e5d2d0", size = 4940, upload-time = "2024-10-31T17:52:33.528Z" },
 ]
 
 [[package]]
@@ -3338,27 +3342,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.63"
+version = "0.0.70"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/ce/cbeaa5c7576fec643609dfbf200d59493523b1cc0481d4e7a5effcbf0630/ty-0.0.63.tar.gz", hash = "sha256:c2f66439393b3acac69306c117d4ae44638ce5fffa4a20c21046e85bd473359f", size = 6280695, upload-time = "2026-07-23T11:41:39.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/ed/38a8ab52f1d7c3ed701442a31b23ba774cbc5d6909f2c00da9e1f3c590f9/ty-0.0.70.tar.gz", hash = "sha256:a01bebc128b4081c16002965d906fccb21323d69bb709b9108c1f2406bcffced", size = 6601156, upload-time = "2026-08-10T23:20:26.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/e4/d17a8e113ab15c692fe6fb9c422112d4bee7e829d80ced35826b45d98d98/ty-0.0.63-py3-none-linux_armv6l.whl", hash = "sha256:9a4ef7782e3af314fb63d006bec5ac3025bd70fee774b4dcfb5e44e8564f1994", size = 12056302, upload-time = "2026-07-23T11:41:03.5Z" },
-    { url = "https://files.pythonhosted.org/packages/be/0b/357234c815dc4bfcc88c3f860aa0983fe4228c8aa2a5bb16c35ee08a94af/ty-0.0.63-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:01eab0ab70d51ad10298aa2d4b058b387a1fe93e5ee52d2a1ee23e9c69ba8354", size = 11737674, upload-time = "2026-07-23T11:41:05.862Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/13/193d9aeeb6774690351cff9fafabd3ae9b54cc225d125e07fa004ce23bdc/ty-0.0.63-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a671b61eaad16178389e05b9c108c9cb75ae8d84968fe55906484f55d6268338", size = 11264191, upload-time = "2026-07-23T11:41:07.963Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/c5843e16759a2b25fc8a7197473474038e585ac9fdaa6fa16aeb6384bf6a/ty-0.0.63-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b255cc83d95c51bb9ee4931303fdbece8cb1d6d7c655eb77a3f2c8f349fb64d6", size = 11818890, upload-time = "2026-07-23T11:41:09.885Z" },
-    { url = "https://files.pythonhosted.org/packages/06/20/adf83ae1fc570d9bb449605e1eeeaa523ad2329ca838a636698b5c135d11/ty-0.0.63-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0da1e8183aa4f893421a173904478021498f542ee41273660538da6649a9631c", size = 11853141, upload-time = "2026-07-23T11:41:12.151Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/90/f8effd846e3ee13486ea08257c13094d58b9f188c5641bf609d6a7d5c09f/ty-0.0.63-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:128f38eb5a67199e3811426386f7ec96f41251ddf45e04ddc0bcbb29d4853245", size = 12545184, upload-time = "2026-07-23T11:41:14.4Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/76/aac3a30d40431eb1d329acea016b248f5b6255e30ef3d28e19447e344be2/ty-0.0.63-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bedf34aff8b0557f2a7119b314a68a9c9e58c1d21554d0e2748f2c5fe6a1f638", size = 13062375, upload-time = "2026-07-23T11:41:16.441Z" },
-    { url = "https://files.pythonhosted.org/packages/62/3d/0158733932893e17f6008dadd74c8d7aed422fefc66e47fe77888014fe8c/ty-0.0.63-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7328d63c34587606dce02935a25404f54cd0161bfe413b8f7fc21d174aead612", size = 12619461, upload-time = "2026-07-23T11:41:18.538Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/be/e280ad095b050778f16f493d49a073fa5f6d8f301d3e2e59be6a672ba05c/ty-0.0.63-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:504c4457f3a62afe836c1f26a2c9a12549299095f9cc4146778558df51a7515c", size = 12376402, upload-time = "2026-07-23T11:41:20.482Z" },
-    { url = "https://files.pythonhosted.org/packages/57/57/619788bf335cb86b090470b557ae1eed33613dc24e12142505d32b462e58/ty-0.0.63-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:7394ed39424b027c89d5f0c818871c791e33958b88f5bb13e14bd4a12a3ca631", size = 12671377, upload-time = "2026-07-23T11:41:22.489Z" },
-    { url = "https://files.pythonhosted.org/packages/07/a2/0aff2cdd3c98e2c4729337542b8da0ce1980790e1600e0c4a717a1f46293/ty-0.0.63-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:94c3f155230490f8fb505911655e940c630c25cc0c35a76690cb413254fb4437", size = 11768090, upload-time = "2026-07-23T11:41:24.558Z" },
-    { url = "https://files.pythonhosted.org/packages/43/4a/cdb5f1d26154144dfee08e1bd671daf827238170f7cee9dad43990bb2016/ty-0.0.63-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:c16e1d8b4f0ae99106d5f13a894034a202baf6cdab61e2bb1a239de82904f839", size = 11867747, upload-time = "2026-07-23T11:41:26.794Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/26/ecc09ecb70bc9fbfdf42fa57ff29568f173e8200df575a0d72dc2b8486f9/ty-0.0.63-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b66293dad89eaed4b9fbf3b661614dbeb85b59ba037178a3f9a0adedf264da5c", size = 12120000, upload-time = "2026-07-23T11:41:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/14/07/862822f9c2c397785b69b25cf79b4dfc3c0d55684b9adf11ac194450f8e1/ty-0.0.63-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8b29cc832e2ec73502c97dd7325d6ae0e085b34a33529a0f785192317d9862fc", size = 12477862, upload-time = "2026-07-23T11:41:30.847Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c2/50b08b641578d6f48e8aa28a91d0de32c91aa24dd926ed199e8afd2d37ea/ty-0.0.63-py3-none-win32.whl", hash = "sha256:f0a8fbfd1f990c0c5d85cce018d438969ac79e49247e2192c9745394bb7d17ab", size = 11433155, upload-time = "2026-07-23T11:41:33.28Z" },
-    { url = "https://files.pythonhosted.org/packages/92/2d/d422a5568f0d1f317186be22241288dc6e08b71dc24aca223f22038ac2d2/ty-0.0.63-py3-none-win_amd64.whl", hash = "sha256:2aa2370bdd6f42e9f37518c812379bef70b9162f9e5aad511495229b0b71cb93", size = 12450036, upload-time = "2026-07-23T11:41:35.559Z" },
-    { url = "https://files.pythonhosted.org/packages/35/97/2c9748e28ead0650c7ad3e5f74f178832ceabd7cb5c272a882f29eb32ee4/ty-0.0.63-py3-none-win_arm64.whl", hash = "sha256:95ac1a62162c3c7ac204731e95ebf766d62a46a7bfa238a6acbe923fcb772cb1", size = 11826243, upload-time = "2026-07-23T11:41:37.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c5/ddd6cc5657fd3da85591b264f4dabb1ce5e5b535e73fd5174991c294978b/ty-0.0.70-py3-none-linux_armv6l.whl", hash = "sha256:4fb2d2e55e2160c07152361be2e1a26fdd4f6261055731317d5972daf1749935", size = 12537215, upload-time = "2026-08-10T23:19:43.512Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8a/acc9b34331cde81e0d63cda92d4db9e4042def5b1efa7d47431ff1d30d17/ty-0.0.70-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9b04d4c21cb029501c05598ca21e9c0829c0b2e35a7ceba1e5b78014c1e8104d", size = 12149070, upload-time = "2026-08-10T23:19:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cd/51ac2708f4d077058a0bfeefa40d630883c5ec7a82fd2c15c86519140235/ty-0.0.70-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c605ebf2643f5e64ec4bcb269640a1aa85966d29fa888fb746039c28570369b2", size = 11625729, upload-time = "2026-08-10T23:19:48.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/99/afc4fe7e630100dc782ff0cdc8c59c01acfb05299551ff0ef49c93814320/ty-0.0.70-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c38ea76e12909c29e18fcd295ff223b63f3701c1d1c34db2cdc9736340b9de2", size = 12204810, upload-time = "2026-08-10T23:19:51.845Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/8cabc3c8ad4c3a02e585ecff12a71ff8e5881f8a00ee71745fd765201da5/ty-0.0.70-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c1ee6bf4edaabf7bd0307f0c0f9ddc2204df0390820fe89f6a9de65f07722aba", size = 12308114, upload-time = "2026-08-10T23:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7e/bb4e552ecd68bb490bae9368ef323e3d0c79ef85a811857139a2d0f59ddb/ty-0.0.70-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5eef3e11d7d6b800ef66da0cce8ea24f8be804d1ebf359683426cfe848729bf8", size = 13072240, upload-time = "2026-08-10T23:19:56.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c4/1861e1d554e5b6e0d11b3a9f36d40c372253f44a3c4e56ad4bf840f2801e/ty-0.0.70-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a95e4ae7c2599197c9d89652e49ca344ab224f7d12376e6ad8beb0587e8ff83f", size = 13497678, upload-time = "2026-08-10T23:19:59.191Z" },
+    { url = "https://files.pythonhosted.org/packages/77/22/3b22442133e8f641485e59e463a070a31184db0d6456851f871db8f59763/ty-0.0.70-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:06aca758d1e0016c0a1f57fe9d8de7a21ff83f692306f747a0d97f32de24e27f", size = 13232510, upload-time = "2026-08-10T23:20:01.456Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b8/911f1e6885b5485b6e1d29aaab19ce5e6deeb3e931b6ad82296da4f22051/ty-0.0.70-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d81825524f1b57ecbcb5fce7d61fb159cb4837a6167a4569309c9fa7fc15a77d", size = 12817128, upload-time = "2026-08-10T23:20:04.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a6/9affc3ca11c32d75b348a66144ab83335fa7fa7100b1581356725e15a668/ty-0.0.70-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3287dfb09f7320ef28f114f5f9aae5f697b7b1a6ee37fb2a4a3be94481c1b4f8", size = 13089208, upload-time = "2026-08-10T23:20:06.574Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/cb/4776108ea08ec4013b71375b101be9c8a632967cd10f24abbdd4664d66f4/ty-0.0.70-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9fb1877f6401cdaac4db46c5bf762f327482ba5f891420ea462ebd15d0de4185", size = 12148890, upload-time = "2026-08-10T23:20:08.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d9/814e71f698d9231ef6412bd2c1499d81c6f86f66c2764e952c991e2d6da5/ty-0.0.70-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e78f4997dbb0db2d2270210eb3694466206e5b3a11985e24148770e702158a25", size = 12327084, upload-time = "2026-08-10T23:20:11.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/69/9f34bba534c5d1ace391d300ead4f1971f4348c5459e66dc466cfd60661c/ty-0.0.70-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cf758d3b2dad910c9b1d22d2d62fea894b5bc9acd3c00365e8a73ace6090a452", size = 12604372, upload-time = "2026-08-10T23:20:13.366Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ff/abb34674517b29a8e2489a39c4e01930fcf6aab993a7d6b33aa97f119117/ty-0.0.70-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0d338761617279a4fb6a83e7fad7e21126394637b8c45e13e196b2bb675f39b2", size = 12917800, upload-time = "2026-08-10T23:20:15.841Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1a/f8289572f4fad5cb16c883b94638548166bc78cf3eb569f0cd9199eb10a0/ty-0.0.70-py3-none-win32.whl", hash = "sha256:a45642cf09dde91f0a3ce9b9e6fffda9779ff69d73f7347c18acf4fb45007c07", size = 11921482, upload-time = "2026-08-10T23:20:18.244Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ae/8739d7618b4670c3ee4f52d641d53be87928bd121d8bda9c0e3450500b75/ty-0.0.70-py3-none-win_amd64.whl", hash = "sha256:33e7941a926cf39b82553911a59a6ed68ec98c3d3d5a415df633f4d1cd051e6c", size = 12986994, upload-time = "2026-08-10T23:20:20.53Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/44/2bc3301ba4356ad8866daac9f8cfb3687953e52d076ea204f113b9304c42/ty-0.0.70-py3-none-win_arm64.whl", hash = "sha256:0d380f735d52b1d4b773193f8f5c58c065725eab1ebb0008d38a7b830de14f47", size = 12301082, upload-time = "2026-08-10T23:20:23.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Including:

* removal of pytest-beartype in favor of runtime detection/use of beartype
  * beartype package inclusion now managed directly by Tox
* bumping ty to 0.0.64 and commensurate cleanup